### PR TITLE
Added Core Particles + finalized categories page

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -8,8 +8,26 @@ use Illuminate\Http\Request;
 
 class CategoryController extends Controller
 {
-    public function start(Language $language, Category $category)
+    public function start(Language $language, Category $category, $direction)
     {
-        return view('categories.start', compact('language', 'category'));
+        if (!in_array($direction, ['recognition', 'recall'])) {
+            abort(404);
+        }
+
+        return view('categories.start', compact('language', 'category', 'direction'));
+    }
+
+
+    public function show(Language $language, Category $category)
+    {
+        // If it has children, show the subcategories
+        if ($category->children()->exists()) {
+            $subcategories = $category->children;
+
+            return view('categories.subcategories', compact('language', 'category', 'subcategories'));
+        }
+
+        // If no children, show direction selection
+        return view('categories.directions', compact('language', 'category'));
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Item extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'category_id',
+        'prompt',
+        'answer',
+        'romaji',
+        'type',
+        'extra_data',
+        'direction',
+    ];
+
+    protected $casts = [
+        'extra_data' => 'array',
+    ];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/database/migrations/2025_04_11_140529_create_items_table.php
+++ b/database/migrations/2025_04_11_140529_create_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            $table->string('prompt');
+            $table->string('answer');
+            $table->string('romaji')->nullable();
+            $table->string('type')->nullable();
+            $table->json('extra_data')->nullable();
+            $table->enum('direction', ['recognition', 'recall']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/database/migrations/2025_04_11_140549_create_category_user_progress_table.php
+++ b/database/migrations/2025_04_11_140549_create_category_user_progress_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('category_user_progress', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            $table->integer('best_accuracy')->nullable();
+            $table->integer('best_time_ms')->nullable();
+            $table->timestamp('last_practiced_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'category_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('category_user_progress');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             LanguagesTableSeeder::class,
             CategoriesTableSeeder::class,
+            ItemsTableSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ItemsTableSeeder.php
+++ b/database/seeders/ItemsTableSeeder.php
@@ -37,6 +37,7 @@ class ItemsTableSeeder extends Seeder
                 'answer' => $particle['meanings'][0],
                 'romaji' => $particle['romaji'],
                 'direction' => 'recognition',
+                'type' => 'Core Particles',
                 'extra_data' => count($particle['meanings']) > 1
                     ? json_encode(['alt_answers' => array_slice($particle['meanings'], 1)])
                     : null,
@@ -49,6 +50,7 @@ class ItemsTableSeeder extends Seeder
                 'answer' => $particle['kana'],
                 'romaji' => $particle['romaji'],
                 'direction' => 'recall',
+                'type' => 'Core Particles',
                 'extra_data' => count($particle['meanings']) > 1
                     ? json_encode(['alt_prompts' => array_slice($particle['meanings'], 1)])
                     : null,

--- a/database/seeders/ItemsTableSeeder.php
+++ b/database/seeders/ItemsTableSeeder.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Database\Seeders;
+
+
+use App\Models\Category;
+use App\Models\Item;
+use Illuminate\Database\Seeder;
+
+class ItemsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $category = Category::where('slug', 'core-particles')->firstOrFail();
+
+        $particles = [
+            ['kana' => 'は', 'romaji' => 'wa', 'meanings' => ['topic marker']],
+            ['kana' => 'を', 'romaji' => 'o', 'meanings' => ['direct object']],
+            ['kana' => 'に', 'romaji' => 'ni', 'meanings' => ['direction', 'time']],
+            ['kana' => 'で', 'romaji' => 'de', 'meanings' => ['place of action', 'means']],
+            ['kana' => 'と', 'romaji' => 'to', 'meanings' => ['and', 'with']],
+            ['kana' => 'も', 'romaji' => 'mo', 'meanings' => ['also', 'too']],
+            ['kana' => 'が', 'romaji' => 'ga', 'meanings' => ['subject', 'emphasis']],
+            ['kana' => 'の', 'romaji' => 'no', 'meanings' => ["possession", "'s"]],
+            ['kana' => 'から', 'romaji' => 'kara', 'meanings' => ['from', 'because']],
+            ['kana' => 'まで', 'romaji' => 'made', 'meanings' => ['until', 'up to']],
+        ];
+
+        foreach ($particles as $particle) {
+            // Recognition: kana → meaning(s)
+            Item::create([
+                'category_id' => $category->id,
+                'prompt' => $particle['kana'],
+                'answer' => $particle['meanings'][0],
+                'romaji' => $particle['romaji'],
+                'direction' => 'recognition',
+                'extra_data' => count($particle['meanings']) > 1
+                    ? json_encode(['alt_answers' => array_slice($particle['meanings'], 1)])
+                    : null,
+            ]);
+
+            // Recall: meaning → kana
+            Item::create([
+                'category_id' => $category->id,
+                'prompt' => $particle['meanings'][0],
+                'answer' => $particle['kana'],
+                'romaji' => $particle['romaji'],
+                'direction' => 'recall',
+                'extra_data' => count($particle['meanings']) > 1
+                    ? json_encode(['alt_prompts' => array_slice($particle['meanings'], 1)])
+                    : null,
+            ]);
+        }
+    }
+}

--- a/resources/views/categories/directions.blade.php
+++ b/resources/views/categories/directions.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="w-full max-w-4xl mx-auto px-6 py-12 text-white">
+        <h2 class="text-3xl font-bold mb-6 drop-shadow-md">
+            {{ $language->name }} — {{ $category->name }}
+        </h2>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <a href="{{ route('category.start', [$language->slug, $category->slug, 'recognition']) }}"
+               class="block bg-white rounded-lg shadow p-6 text-[#111827] hover:shadow-lg transition">
+                <h3 class="text-xl font-semibold mb-2">Recognition</h3>
+                <p class="text-sm text-gray-600">See Japanese, type the meaning.</p>
+            </a>
+
+            <a href="{{ route('category.start', [$language->slug, $category->slug, 'recall']) }}"
+               class="block bg-white rounded-lg shadow p-6 text-[#111827] hover:shadow-lg transition">
+                <h3 class="text-xl font-semibold mb-2">Recall</h3>
+                <p class="text-sm text-gray-600">See meaning, type the Japanese (or romaji).</p>
+            </a>
+        </div>
+    </section>
+@endsection

--- a/resources/views/categories/start.blade.php
+++ b/resources/views/categories/start.blade.php
@@ -9,7 +9,7 @@
         <div class="bg-white rounded-lg shadow p-6 text-[#111827]">
             <h3 class="text-xl font-semibold mb-2">Coming Soon</h3>
             <p class="text-gray-600">
-                You’ve selected the category <strong>{{ $category->name }}</strong> in <strong>{{ $language->name }}</strong>. We're still working on this feature — stay tuned!
+                You selected <strong>{{ $category->name }}</strong> in <strong>{{ $language->name }}</strong> with mode <strong>{{ ucfirst($direction) }}</strong>.
             </p>
         </div>
     </section>

--- a/resources/views/categories/subcategories.blade.php
+++ b/resources/views/categories/subcategories.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="w-full max-w-7xl mx-auto px-6 py-12 text-white">
+        <h2 class="text-3xl font-bold mb-8 drop-shadow-md">
+            {{ $language->name }} — {{ $category->name }} Subcategories
+        </h2>
+
+        @if ($subcategories->isEmpty())
+            <p class="text-white/80">No subcategories found.</p>
+        @else
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                @foreach ($subcategories as $subcategory)
+                    <div class="bg-white p-6 rounded-lg shadow hover:shadow-lg transition text-[#111827]">
+                        <h3 class="text-xl font-semibold mb-2">{{ $subcategory->name }}</h3>
+                        <p class="text-sm text-gray-600 mb-4">{{ $subcategory->description ?? 'Start practicing now.' }}</p>
+                        <a href="{{ route('category.show', [$language->slug, $subcategory->slug]) }}"
+                           class="inline-block px-4 py-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-md text-sm font-medium shadow hover:brightness-110 transition">
+                            Select
+                        </a>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </section>
+@endsection

--- a/resources/views/languages/categories.blade.php
+++ b/resources/views/languages/categories.blade.php
@@ -19,7 +19,7 @@
                             <h3 class="text-xl font-semibold mb-2">{{ $category->name }}</h3>
                             <p class="text-sm text-gray-600 mb-4">{{ $category->description ?? 'Start practicing now.' }}</p>
                         </div>
-                        <a href="{{ route('category.start', [$language->slug, $category->slug]) }}"
+                        <a href="{{ route('category.show', [$language->slug, $category->slug]) }}"
                            class="inline-block px-4 py-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-md text-sm font-medium shadow hover:brightness-110 transition">
                             Start
                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,9 +26,14 @@ Route::get('/languages', [LanguageController::class, 'index'])
 
 Route::get('/languages/{language:slug}/categories', [LanguageController::class, 'categories'])->name('languages.categories');
 
-Route::get('/languages/{language:slug}/categories/{category:slug}/start', [CategoryController::class, 'start'])
+Route::get('/languages/{language:slug}/{category:slug}', [CategoryController::class, 'show'])
+    ->middleware(['auth', 'verified'])
+    ->name('category.show');
+
+Route::get('/languages/{language:slug}/{category:slug}/{direction}', [CategoryController::class, 'start'])
     ->middleware(['auth', 'verified'])
     ->name('category.start');
+
 
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
- Added migration for the items database table.
- Added migration for category progress database table.
- Added Item model.
- Added Items database seeder including all the Core Particles (recognition & recall version).
- Edit routing for categories so that subcategories and learning directions can be chosen.
- Added blade for subcategories and learning directions.
- Edit categories start.blade to showcase the correct category picked and which learning direction has been chosen by the user (temporary until gamified version gets implemented).
- Edit categories.blade to redirect to category.show to implement choosing subcategories (if there are any) and learning directions.