### PR TITLE
Feature: Personal Leaderboards

### DIFF
--- a/app/Http/Controllers/LeaderboardController.php
+++ b/app/Http/Controllers/LeaderboardController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Models\Language;
+use App\Models\TimedAttempt;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+
+class LeaderboardController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+
+        // Get all categories/subcategories the user has played in
+        $categoryIds = TimedAttempt::where('user_id', $user->id)
+            ->pluck('category_id')
+            ->unique();
+
+        $categories = Category::with('parent', 'language')
+            ->whereIn('id', $categoryIds)
+            ->get();
+
+        return view('leaderboards.personal_index', compact('categories'));
+    }
+
+    public function personal(Language $language, Category $category, $direction)
+    {
+        if (!in_array($direction, ['recognition', 'recall'])) {
+            abort(404);
+        }
+
+        $user = auth()->user();
+
+        $attempts = TimedAttempt::where('user_id', $user->id)
+            ->where('category_id', $category->id)
+            ->where('direction', $direction)
+            ->orderByRaw('(correct / (correct + missed)) DESC')
+            ->orderBy('time_ms', 'ASC')
+            ->paginate(20);
+
+        // Enhance each attempt with display data
+        foreach ($attempts as $index => $attempt) {
+            $rank = ($attempts->currentPage() - 1) * $attempts->perPage() + $index + 1;
+
+            $accuracy = $attempt->correct + $attempt->missed > 0
+                ? round(($attempt->correct / ($attempt->correct + $attempt->missed)) * 100)
+                : 0;
+
+            $formattedTime = sprintf('%02d:%02d:%02d.%02d',
+                floor($attempt->time_ms / 3600000),
+                floor(($attempt->time_ms % 3600000) / 60000),
+                floor(($attempt->time_ms % 60000) / 1000),
+                floor(($attempt->time_ms % 1000) / 10)
+            );
+
+            $rowClass = match ($rank) {
+                1 => 'bg-yellow-400 text-black',
+                2 => 'bg-gray-300 text-black',
+                3 => 'bg-orange-400 text-black',
+                default => 'bg-white/10 text-white'
+            };
+
+            // Attach values to the model instance
+            $attempt->rank = $rank;
+            $attempt->accuracy_percent = $accuracy;
+            $attempt->formatted_time = $formattedTime;
+            $attempt->formatted_date = Carbon::parse($attempt->finished_at)->format('d-m-Y H:i ');
+            $attempt->row_class = $rowClass;
+        }
+
+        return view('leaderboards.personal', compact('attempts', 'language', 'category', 'direction'));
+    }
+}

--- a/app/Http/Controllers/TimedController.php
+++ b/app/Http/Controllers/TimedController.php
@@ -211,7 +211,7 @@ class TimedController extends Controller
             'correct' => $correct,
             'missed' => $missed,
             'time_ms' => $timeMs,
-            'attempt' => $attemptNumber,
+            'attempt_number' => $attemptNumber,
             'finished_at' => $endTime,
         ]);
 

--- a/app/Http/Controllers/TimedController.php
+++ b/app/Http/Controllers/TimedController.php
@@ -197,6 +197,13 @@ class TimedController extends Controller
         $previousTimeMs = null;
         $previousFormattedTime = null;
 
+        // Calculate current attempt number
+        $attemptCount = TimedAttempt::where('user_id', $user->id)
+            ->where('category_id', $categoryId)
+            ->where('direction', $direction)
+            ->count();
+        $attemptNumber = $attemptCount + 1;
+
         TimedAttempt::create([
             'user_id' => $user->id,
             'category_id' => $categoryId,
@@ -204,6 +211,7 @@ class TimedController extends Controller
             'correct' => $correct,
             'missed' => $missed,
             'time_ms' => $timeMs,
+            'attempt' => $attemptNumber,
             'finished_at' => $endTime,
         ]);
 
@@ -293,5 +301,4 @@ class TimedController extends Controller
             'processedSkipped'
         ));
     }
-
 }

--- a/app/Models/CategoryUserProgress.php
+++ b/app/Models/CategoryUserProgress.php
@@ -17,6 +17,11 @@ class CategoryUserProgress extends Model
         'last_practiced_at',
     ];
 
+    protected $casts = [
+        'best_accuracy' => 'integer',
+        'best_time_ms' => 'integer',
+    ];
+
     public function category()
     {
         return $this->belongsTo(Category::class);

--- a/app/Models/TimedAttempt.php
+++ b/app/Models/TimedAttempt.php
@@ -16,4 +16,8 @@ class TimedAttempt extends Model
         'attempt_number',
         'finished_at',
     ];
+
+    protected $casts = [
+        'time_ms' => 'integer',
+    ];
 }

--- a/app/Models/TimedAttempt.php
+++ b/app/Models/TimedAttempt.php
@@ -13,6 +13,7 @@ class TimedAttempt extends Model
         'correct',
         'missed',
         'time_ms',
+        'attempt_number',
         'finished_at',
     ];
 }

--- a/database/migrations/2025_04_23_184819_add_attempt_number_to_timed_attempts_table.php
+++ b/database/migrations/2025_04_23_184819_add_attempt_number_to_timed_attempts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('timed_attempts', function (Blueprint $table) {
+            $table->unsignedInteger('attempt_number')->after('time_ms');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('timed_attempts', function (Blueprint $table) {
+            $table->dropColumn('attempt_number');
+        });
+    }
+};

--- a/resources/views/leaderboards/personal.blade.php
+++ b/resources/views/leaderboards/personal.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="w-full max-w-7xl mx-auto px-6 py-12 text-white">
+        <h2 class="text-3xl font-bold drop-shadow-md mb-4">{{ $category->name }}</h2>
+
+        @if ($category->parent)
+            <p class="text-white/80 mb-6 text-sm">Subcategory of: {{ $category->parent->name }}</p>
+        @endif
+
+    <!-- Toggles -->
+        <div class="flex justify-between items-center mb-6 flex-wrap gap-4">
+            <div class="flex gap-2">
+                <a href="{{ route('leaderboard.personal', [$language->slug, $category->slug, 'recognition']) }}"
+                   class="px-4 py-2 rounded-md {{ $direction === 'recognition' ? 'bg-white text-[#111827]' : 'bg-white/10 text-white hover:bg-white/20' }}">
+                    Recognition
+                </a>
+                <a href="{{ route('leaderboard.personal', [$language->slug, $category->slug, 'recall']) }}"
+                   class="px-4 py-2 rounded-md {{ $direction === 'recall' ? 'bg-white text-[#111827]' : 'bg-white/10 text-white hover:bg-white/20' }}">
+                    Recall
+                </a>
+            </div>
+
+            <div class="flex gap-2">
+                <span class="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-semibold shadow">
+                    Personal
+                </span>
+                <a href="#" class="bg-white/10 hover:bg-white/20 text-white px-4 py-2 rounded-md text-sm font-medium transition">
+                    Global
+                </a>
+            </div>
+        </div>
+
+        @if ($attempts->isEmpty())
+            <p class="text-white/80">You have no personal attempts for this category and direction yet.</p>
+        @else
+            <div class="overflow-x-auto">
+                <table class="w-full table-auto border-separate border-spacing-y-2">
+                    <thead class="text-left text-sm uppercase tracking-wide text-white/70">
+                    <tr>
+                        <th>Rank</th>
+                        <th>Accuracy %</th>
+                        <th>Time</th>
+                        <th>Attempt #</th>
+                        <th>Date</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach ($attempts as $attempt)
+                        <tr class="{{ $attempt->row_class }} rounded-md">
+                            <td class="px-4 py-2 font-semibold">{{ $attempt->rank }}</td>
+                            <td class="px-4 py-2">{{ $attempt->accuracy_percent }}%</td>
+                            <td class="px-4 py-2">{{ $attempt->formatted_time }}</td>
+                            <td class="px-4 py-2">{{ $attempt->attempt_number ?? '-' }}</td>
+                            <td class="px-4 py-2">{{ $attempt->formatted_date }}</td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="mt-6">
+                {{ $attempts->links() }}
+            </div>
+        @endif
+    </section>
+@endsection

--- a/resources/views/leaderboards/personal_index.blade.php
+++ b/resources/views/leaderboards/personal_index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="w-full max-w-7xl mx-auto px-6 py-12 text-white">
+        <h2 class="text-3xl font-bold mb-8 drop-shadow-md">Your Leaderboards</h2>
+
+        @if ($categories->isEmpty())
+            <p class="text-white/80">You haven't started any categories yet in Timed Mode.</p>
+            <a href="{{ route('dashboard') }}"
+               class="inline-block mt-6 px-6 py-3 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-medium rounded-md shadow hover:brightness-110 transition">
+                Go to Dashboard
+            </a>
+        @else
+            <div class="space-y-10">
+                @foreach ($categories->groupBy('language.name') as $languageName => $groupedCategories)
+                    <div>
+                        <h3 class="text-2xl font-semibold text-white mb-4 drop-shadow">{{ $languageName }}</h3>
+
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            @foreach ($groupedCategories as $category)
+                                <div class="bg-white p-6 rounded-lg shadow-sm text-[#111827] flex flex-col justify-between h-full">
+                                    <div>
+                                        <div class="text-lg font-bold mb-2">{{ $category->name }}</div>
+
+                                        <div class="text-sm text-gray-500 mb-4 min-h-[1.25rem]">
+                                            @if ($category->parent)
+                                                Subcategory of: {{ $category->parent->name }}
+                                            @endif
+                                        </div>
+
+                                        <div class="flex flex-col gap-2">
+                                            <a href="{{ route('leaderboard.personal', [$category->language->slug, $category->slug, 'recognition']) }}"
+                                               class="block w-full px-4 py-2 bg-gradient-to-r from-blue-500 to-indigo-600 text-white text-sm font-medium rounded-md shadow hover:brightness-110 text-center">
+                                                Recognition Leaderboard
+                                            </a>
+                                            <a href="{{ route('leaderboard.personal', [$category->language->slug, $category->slug, 'recall']) }}"
+                                               class="block w-full px-4 py-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white text-sm font-medium rounded-md shadow hover:brightness-110 text-center">
+                                                Recall Leaderboard
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </section>
+@endsection

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -19,7 +19,7 @@
                    class="px-6 py-2.5 bg-white/10 hover:bg-white/20 text-white rounded-md font-medium transition text-base">
                     Languages
                 </a>
-                <a href="{{ route('dashboard') }}"
+                <a href="{{ route('leaderboard.personal_index') }}"
                    class="px-6 py-2.5 bg-white/10 hover:bg-white/20 text-white rounded-md font-medium transition text-base">
                     Leaderboards
                 </a>

--- a/resources/views/timed/complete.blade.php
+++ b/resources/views/timed/complete.blade.php
@@ -38,6 +38,17 @@
                     ⏱️ New Fastest Time!
                 </div>
             @endif
+            @if ($newBestAccuracy || $newBestTime)
+                <a href="{{ route('leaderboard.personal', [$language->slug, $category->slug, $direction]) }}"
+                   class="mt-6 inline-block px-6 py-3 bg-gradient-to-r from-yellow-500 to-orange-500 text-white font-medium rounded-md shadow hover:brightness-110 transition animate-pulse">
+                    🌟 You ranked higher! Check Leaderboard
+                </a>
+            @else
+                <a href="{{ route('leaderboard.personal', [$language->slug, $category->slug, $direction]) }}"
+                   class="mt-6 inline-block px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-600 text-white font-medium rounded-md shadow hover:brightness-110 transition">
+                    🏆 View Leaderboard for This Category
+                </a>
+            @endif
         </div>
 
         <div class="mt-6 flex flex-col sm:flex-row gap-4 justify-center">

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\LanguageController;
 use App\Http\Controllers\LanguagePreferenceController;
+use App\Http\Controllers\LeaderboardController;
 use App\Http\Controllers\PracticeController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TimedController;
@@ -85,5 +86,13 @@ Route::post('/timed/skip', [TimedController::class, 'skip'])
 Route::get('/timed/results', [TimedController::class, 'results'])
     ->middleware(['auth', 'verified'])
     ->name('timed.results');
+
+Route::get('/leaderboards/personal', [LeaderboardController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('leaderboard.personal_index');
+
+Route::get('/leaderboards/personal/{language:slug}/{category:slug}/{direction}', [LeaderboardController::class, 'personal'])
+    ->middleware(['auth', 'verified'])
+    ->name('leaderboard.personal');
 
 require __DIR__.'/auth.php';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,11 @@ export default {
         './resources/views/**/*.blade.php',
     ],
 
+    safelist: [
+        'bg-yellow-400', 'bg-gray-300', 'bg-orange-400', 'bg-white/10',
+        'text-white', 'text-black',
+    ],
+
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
Users now can see their own timed mode attempts in a personal leaderboard. The leaderboard shows the top 20 rankings per page with extra data for users to check. 

It will show:
- Rank
- Accuracy %
- Time
- Attempt Number
- Date/Time of the attempt

Top 3 has been made extra clear by adding bronze, silver, and gold to those ranks to make them stand out more. Leaderboard index will show only the categories and subcategories the user has played, so users can only see those leaderboards